### PR TITLE
Config updates

### DIFF
--- a/config/Universal Tweaks - General.cfg
+++ b/config/Universal Tweaks - General.cfg
@@ -10,7 +10,7 @@ general {
         B:"Debug Logging"=false
 
         # Prints the time the game needed to launch to the log
-        B:"Show Loading Time"=true
+        B:"Show Loading Time"=false
     }
 
 }

--- a/config/packupdater.cfg
+++ b/config/packupdater.cfg
@@ -2,7 +2,7 @@
 
 "mod pack information" {
     # The current version of your mod pack. [default: UNKNOWN]
-    S:"Mod pack current version"=1.0
+    S:"Mod pack current version"=1.1
 
     # The name of your mod pack. [default: UNKNOWN]
     S:"Mod pack name"=Modernized 1.12

--- a/config/sledgehammer.conf
+++ b/config/sledgehammer.conf
@@ -49,7 +49,7 @@ mixin {
     # AbyssalCraft
     abyssalcraft {
         # If 'true', fixes item duplication
-        item-duplication=false
+        item-duplication=true
     }
     # Actually Additions
     actually-additions {
@@ -217,7 +217,7 @@ mixin {
     # Embers
     embers {
         # If 'true', fixes item duplication
-        item-duplication=false
+        item-duplication=true
     }
     # Ender Storage
     enderstorage {
@@ -356,7 +356,7 @@ mixin {
     # Real Filing Cabinet
     realfilingcabinet {
         # If 'true', fixes item duplication
-        item-duplication=false
+        item-duplication=true
     }
     # Ruins (Structure Spawning System)
     ruins {
@@ -397,7 +397,7 @@ mixin {
         # If 'true', fixes magnetic trait voiding items
         magnetic-void=false
         # If 'true', fixes item duplication when renaming items in the Tool Forge
-        text-sync=false
+        text-sync=true
     }
     # Thaumic Wonders
     thaumicwonders {


### PR DESCRIPTION
There were two mods logging launch time : Universal Tweaks and VintageFix. This PR disables Universal Tweak's
Remove dupes in various mods in sledgehammer.cfg (dupes not covered by Unitweaks)
Updated current pack version in packupdater.cfg