### PR TITLE
More Random Stuff

### DIFF
--- a/config/futuremc/futuremc.cfg
+++ b/config/futuremc/futuremc.cfg
@@ -200,7 +200,7 @@ general {
         B:Lantern=true
 
         # Whether the 1.12 villager screen is replaced by FutureMC's 1.14 villager screen
-        B:"New Villager Gui Screen"=true
+        B:"New Villager Gui Screen"=false
 
         # Whether the Panda is enabled.
         B:Panda=true

--- a/config/quark.cfg
+++ b/config/quark.cfg
@@ -61,7 +61,7 @@ automation {
     B:"Animals eat floor food"=true
     B:"Chain linkage"=true
     B:Chute=true
-    B:"Color slime"=true
+    B:"Color slime"=false
     B:"Dispenser records"=true
     B:"Dispensers place blocks"=false
     B:"Dispensers place seeds"=true
@@ -161,7 +161,7 @@ automation {
 
     "chain linkage" {
         # Can vehicle-linking chains be used for crafting chain armor?
-        B:"Crafts Armor"=true
+        B:"Crafts Armor"=false
     }
 
     "dispensers place seeds" {
@@ -192,7 +192,7 @@ building {
     B:"Midori blocks"=true
     B:"More sandstone"=true
     B:"Polished netherrack"=true
-    B:"Polished stone"=false
+    B:"Polished stone"=true
     B:"Quilted wool"=true
     B:"Sandy bricks"=true
     B:"Snow bricks"=true
@@ -495,6 +495,7 @@ client {
             oe:trident
             minecraft:elytra
             quark:pickarang
+            deeperdepths:mace
          >
     }
 
@@ -579,7 +580,7 @@ decoration {
     B:"Paper wall"=true
     B:"Place blaze rods"=true
     B:Rope=true
-    B:"Tallow and candles"=true
+    B:"Tallow and candles"=false
     B:"Tie fences"=true
     B:"Varied bookshelves"=true
     B:"Varied buttons and pressure plates"=true
@@ -629,6 +630,10 @@ decoration {
             quark:glowshroom->1
             botania:specialflower->0
             botania:floatingspecialflower->0
+            minecraft:torch->14
+            minecraft:redstone_torch->14
+            futuremc:soul_fire_torch->14
+            oe:underwater_torch->14
          >
     }
 
@@ -803,7 +808,7 @@ management {
     B:"Chest buttons"=true
     B:"Chests in boats"=true
     B:"Ctrl-click an item to favorite it. Favorited items aren't stored by the other features here"=true
-    B:"Inventory sorting"=true
+    B:"Inventory sorting"=false
     B:"Press Ctrl-DELETE in the inventory to delete an item"=true
     B:"Press F in the inventory to switch item to main hand"=true
     B:"Press T in the inventory to link items to chat"=true
@@ -1561,7 +1566,7 @@ tweaks {
         B:"Force Enabled"=false
 
         # The percentage of the (non-afk) server that needs to be sleeping for the time to change.
-        I:"Required Percentage"=100
+        I:"Required Percentage"=51
 
         # How many ticks are required for a player to be marked AFK
         I:"Time for AFK"=2400

--- a/scripts/example_mob_drops.zs
+++ b/scripts/example_mob_drops.zs
@@ -1,0 +1,66 @@
+#modloaded loottweaker
+
+import loottweaker.Conditions;
+import loottweaker.LootTweaker.getTable as Table;
+
+var pool as loottweaker.LootPool;
+
+//Replaces drowned's gold drop with copper
+if (true){
+    //Accesses assets/oe/loot_tables/entities/drowned.json. That is a loot table 
+    //https://github.com/SirSquidly/Oceanic-Expanse/blob/master/src/main/resources/assets/oe/loot_tables/entities/drowned.json
+    val drowned = Table("oe:entities/drowned");
+    val drowned_captain = Table("oe:entities/drowned_captain");
+
+    pool = drowned.getPool("drowned_rare_drop");
+    //We are now in the second pool, the one containing the gold ingot
+    //First, we want to increase the chance of the pool getting rolled, as copper loot in vanilla is 11%, not 5%
+    //We can see in the github that this is a Condition
+    //LootTweaker doesn't let us remove some conditions, so we clear them and then add back the ones we want
+    //Conditions list : https://loottweaker-docs.readthedocs.io/en/latest/type-docs/conditions.html 
+    pool.clearConditions();
+    pool.addConditions([
+        Conditions.killedByPlayer(), //As per vanilla
+        Conditions.randomChanceWithLooting(0.11, 0.02) //Base and per-level increase
+    ]);
+    //Now, we only need to swap the item
+    //You can see that is in an item entry
+    //As our target entry doesn't have an entryName, we must clear all and readd the useful ones
+    pool.clearEntries();
+    //No need for fanciness, we can see the original entry isn't complicated - using oreDict in case Deeper Depths is removed
+    pool.addItemEntry(<ore:ingotCopper>.firstItem, 1);
+
+
+    //Captain is midly different, but much the same
+    //This is what it would look like in a script
+    pool = Table("oe:entities/drowned_captain").getPool("drowned_rare_drop");
+    pool.clearConditions();
+    pool.clearEntries();
+    pool.addConditions([
+        Conditions.killedByPlayer(),
+        Conditions.randomChanceWithLooting(0.22, 0.04)
+    ]);
+    pool.addItemEntry(<ore:ingotCopper>.firstItem, 1);
+
+    //You can see the new loot table in minecraft/dumps/loot_tables after running /ct loottables all
+}
+//Done!
+
+//Adds more rare monster loot. Disabled by default, but are exmaples
+    if (false){//Husks drop gold
+        //Replacing item entry
+        pool = Table("minecraft:entities/husk").getPool("pool1");
+        //entryName is already a thing. We can thererfore juste remove it
+        pool.removeEntry("minecraft:iron_ingot");
+        pool.addItemEntry(<minecraft:gold_ingot>,1);
+    }
+    if (false){//Endermen drop biotite
+        //Adding an entire pool
+        pool = Table("minecraft:entities/enderman").addPool("biotite", 1, 1, 0 ,0); //name, min, max, minBonus, maxBonus
+        pool.addConditions([
+            Conditions.killedByPlayer(),
+            Conditions.randomChanceWithLooting(0.11, 0.02)
+        ]);
+        pool.addItemEntry(<quark:biotite>, 1);
+    }
+//Done!

--- a/scripts/modernized_backport.zs
+++ b/scripts/modernized_backport.zs
@@ -32,3 +32,14 @@ import crafttweaker.item.IItemStack;
         }
     //Done!
 //Done!
+
+//OE tropical slime is slime
+    <ore:slimeball>.add(<oe:blue_slime_ball>);
+    <ore:blockSlime>.add(<oe:blue_slime_block>);
+    recipes.removeByRecipeName("minecraft:slime");
+    recipes.addShaped(<minecraft:slime>, [
+        [<minecraft:slime_ball>, <minecraft:slime_ball>, <minecraft:slime_ball>],
+        [<minecraft:slime_ball>, <minecraft:slime_ball>, <minecraft:slime_ball>],
+        [<minecraft:slime_ball>, <minecraft:slime_ball>, <minecraft:slime_ball>]
+    ]);
+//Done!


### PR DESCRIPTION
Remove Quark Colored Slime as redundant with Honey and Tropical Slime
Iron Chain can't craft chain armor (keeping the collector feeling)
Remove Quark Inventory Sorting as redundant with Inventory Bogo Sorter
Set % of players sleeping to 51
Added OE tropical slime to <ore:slimeball>,  made vanilla slime block only craftable with vanilla slime balls
Add example mob drops, drowned copper by default (as per newer versions)
Disable FutureMC's Trading Screen as redundant with Gambing Style